### PR TITLE
WIP show eval order bug with by-name lambdas

### DIFF
--- a/src/test/scala/scala/async/neg/NakedAwait.scala
+++ b/src/test/scala/scala/async/neg/NakedAwait.scala
@@ -180,4 +180,18 @@ class NakedAwait {
         |""".stripMargin
     }
   }
+
+  @Test
+  def byNameFunctionArgIllegal(): Unit = {
+    expectError("await must not be used under a lazy val initializer") {
+      """
+        | import _root_.scala.async.internal.AsyncId._
+        | def foo(x: String)(a: => String): String = a.reverse
+        | def fooAsByNameLambda = foo("") _
+        | async { fooAsByNameLambda(await("")) }
+        | ()
+        |
+        |""".stripMargin
+    }
+  }
 }


### PR DESCRIPTION
```
 def apply(tr$async: scala.util.Try[Any]): Unit = while$macro$1(){
      try {
        stateMachine$async.this.state$async match {
          case 0 => {
            <synthetic> val awaitable$async$1: String("arg") @scala.reflect.internal.annotations.uncheckedBounds = "arg";
            stateMachine$async.this.state$async = 1;
            this.apply(Success.apply[String @scala.reflect.internal.annotations.uncheckedBounds](awaitable$async$1));
            return ()
          }
          case 2 => {
            {
              stateMachine$async.this.result$async.a_=(Success.apply[String]({
  <synthetic> val v1$async$1: String = stateMachine$async.this.await$async$0;
  fooAsByNameLambda.apply(v1$async$1)
}).get);
              ()
            };
            return ()
          }
          case 1 => {
            if (tr$async.isFailure)
              {
                stateMachine$async.this.result$async.a_=(tr$async.asInstanceOf[scala.util.Try[String]].get);
                return ()
              }
            else
              {
                stateMachine$async.this.await$async$0 = tr$async.get.asInstanceOf[String];
                stateMachine$async.this.state$async = 2
              };
            ()
          }
          case _ => throw new IllegalStateException()
```